### PR TITLE
Move "no fields" text to new component

### DIFF
--- a/editor/src/components/misc/EmptyState.svelte
+++ b/editor/src/components/misc/EmptyState.svelte
@@ -1,7 +1,3 @@
-<script>
-  import { userRole } from '../../stores/app';
-</script>
-
 <p class="description">
   <slot />
 </p>

--- a/editor/src/components/misc/EmptyState.svelte
+++ b/editor/src/components/misc/EmptyState.svelte
@@ -2,12 +2,12 @@
   import { userRole } from '../../stores/app';
 </script>
 
-<p class="empty-description">
+<p class="description">
   <slot />
 </p>
 
 <style lang="postcss">
-  .empty-description {
+  .description {
     color: var(--color-gray-4);
     font-size: var(--font-size-2);
     text-align: center;

--- a/editor/src/components/misc/EmptyState.svelte
+++ b/editor/src/components/misc/EmptyState.svelte
@@ -3,13 +3,7 @@
 </script>
 
 <p class="empty-description">
-  {#if $userRole === 'developer'}
-    You'll need to create and integrate a field before you can edit
-    content from here
-  {:else}
-    The site developer will need to create and integrate a field before
-    you can edit content from here
-  {/if}
+  <slot />
 </p>
 
 <style lang="postcss">

--- a/editor/src/components/misc/NoFieldMessage.svelte
+++ b/editor/src/components/misc/NoFieldMessage.svelte
@@ -1,0 +1,27 @@
+<script>
+  import { userRole } from '../../stores/app';
+</script>
+
+<p class="empty-description">
+  {#if $userRole === 'developer'}
+    You'll need to create and integrate a field before you can edit
+    content from here
+  {:else}
+    The site developer will need to create and integrate a field before
+    you can edit content from here
+  {/if}
+</p>
+
+<style lang="postcss">
+  .empty-description {
+    color: var(--color-gray-4);
+    font-size: var(--font-size-2);
+    text-align: center;
+    height: 100%;
+    display: flex;
+    align-items: flex-start;
+    padding: 6rem;
+    justify-content: center;
+    margin-top: 12px;
+  }
+</style>

--- a/editor/src/components/misc/NoFieldsMessage.svelte
+++ b/editor/src/components/misc/NoFieldsMessage.svelte
@@ -1,0 +1,14 @@
+<script>
+  import { userRole } from '../../stores/app';
+  import { EmptyState } from './';
+</script>
+
+<EmptyState>
+  {#if $userRole === 'developer'}
+    You'll need to create and integrate a field before you can edit
+    content from here
+  {:else}
+    The site developer will need to create and integrate a field before
+    you can edit content from here
+  {/if}
+</EmptyState>

--- a/editor/src/components/misc/index.js
+++ b/editor/src/components/misc/index.js
@@ -3,11 +3,13 @@ import Card from './Card.svelte'
 import Spinner from './Spinner.svelte'
 import Tabs from './Tabs.svelte'
 import CodePreview from './CodePreview.svelte'
+import NoFieldMessage from './NoFieldMessage.svelte'
 
 export {
   IconButton,
   Card,
   Spinner,
   Tabs,
-  CodePreview
+  CodePreview,
+  NoFieldMessage,
 }

--- a/editor/src/components/misc/index.js
+++ b/editor/src/components/misc/index.js
@@ -3,7 +3,8 @@ import Card from './Card.svelte'
 import Spinner from './Spinner.svelte'
 import Tabs from './Tabs.svelte'
 import CodePreview from './CodePreview.svelte'
-import NoFieldMessage from './NoFieldMessage.svelte'
+import EmptyState from './EmptyState.svelte'
+import NoFieldsMessage from './NoFieldsMessage.svelte'
 
 export {
   IconButton,
@@ -11,5 +12,6 @@ export {
   Spinner,
   Tabs,
   CodePreview,
-  NoFieldMessage,
+  EmptyState,
+  NoFieldsMessage,
 }

--- a/editor/src/views/modal/ComponentEditor/ComponentEditor.svelte
+++ b/editor/src/views/modal/ComponentEditor/ComponentEditor.svelte
@@ -4,7 +4,7 @@
   import { getPlaceholderValue, getEmptyValue } from '../../../utils';
   import ModalHeader from '../ModalHeader.svelte';
   import { PrimaryButton } from '../../../components/buttons';
-  import { Tabs, Card } from '../../../components/misc';
+  import { Tabs, Card, NoFieldMessage } from '../../../components/misc';
   import FullCodeEditor from './FullCodeEditor.svelte';
   import { CodePreview } from '../../../components/misc';
   import RepeaterField from '../../../components/FieldTypes/RepeaterField.svelte';
@@ -482,10 +482,7 @@
               </div>
             {/if}
           {:else}
-            <p class="empty-description">
-              You'll need to create and integrate a field before you can edit
-              this component's content from here
-            </p>
+            <NoFieldMessage />
           {/each}
         </div>
       {/if}
@@ -514,18 +511,6 @@
 
     --PrimaryButton-bg: var(--color-gray-8);
     --PrimaryButton-bg-hover: var(--color-gray-9);
-
-    .empty-description {
-      color: var(--color-gray-4);
-      font-size: var(--font-size-2);
-      text-align: center;
-      height: 100%;
-      display: flex;
-      align-items: flex-start;
-      padding: 6rem;
-      justify-content: center;
-      margin-top: 12px;
-    }
   }
 
   .field-item {

--- a/editor/src/views/modal/ComponentEditor/ComponentEditor.svelte
+++ b/editor/src/views/modal/ComponentEditor/ComponentEditor.svelte
@@ -4,7 +4,7 @@
   import { getPlaceholderValue, getEmptyValue } from '../../../utils';
   import ModalHeader from '../ModalHeader.svelte';
   import { PrimaryButton } from '../../../components/buttons';
-  import { Tabs, Card, NoFieldMessage } from '../../../components/misc';
+  import { Tabs, Card, NoFieldsMessage } from '../../../components/misc';
   import FullCodeEditor from './FullCodeEditor.svelte';
   import { CodePreview } from '../../../components/misc';
   import RepeaterField from '../../../components/FieldTypes/RepeaterField.svelte';
@@ -482,7 +482,7 @@
               </div>
             {/if}
           {:else}
-            <NoFieldMessage />
+            <NoFieldsMessage />
           {/each}
         </div>
       {/if}

--- a/editor/src/views/modal/Fields.svelte
+++ b/editor/src/views/modal/Fields.svelte
@@ -1,7 +1,7 @@
 <script>
   import { find, cloneDeep, isEqual, chain as _chain } from 'lodash-es';
   import { EditField } from '../../components/inputs';
-  import { Tabs, Card, NoFieldMessage } from '../../components/misc';
+  import { Tabs, Card, NoFieldsMessage } from '../../components/misc';
   import { createUniqueID } from '../../utilities';
   import {getEmptyValue} from '../../utils'
 
@@ -499,7 +499,7 @@
         </div>
       {/if}
     {:else}
-      <NoFieldMessage />
+      <NoFieldsMessage />
     {/each}
   {:else}
     {#each localSiteFields as field}
@@ -513,7 +513,7 @@
         </div>
       {/if}
     {:else}
-      <NoFieldMessage />
+      <NoFieldsMessage />
     {/each}
   {/if}
 </main>

--- a/editor/src/views/modal/Fields.svelte
+++ b/editor/src/views/modal/Fields.svelte
@@ -1,8 +1,7 @@
 <script>
   import { find, cloneDeep, isEqual, chain as _chain } from 'lodash-es';
   import { EditField } from '../../components/inputs';
-  import { Tabs } from '../../components/misc';
-  import { Card } from '../../components/misc';
+  import { Tabs, Card, NoFieldMessage } from '../../components/misc';
   import { createUniqueID } from '../../utilities';
   import {getEmptyValue} from '../../utils'
 
@@ -500,15 +499,7 @@
         </div>
       {/if}
     {:else}
-      <p class="empty-description">
-        {#if $userRole === 'developer'}
-          You'll need to create and integrate a field before you can edit
-          content from here
-        {:else}
-          The site developer will need to create and integrate a field before
-          you can edit content from here
-        {/if}
-      </p>
+      <NoFieldMessage />
     {/each}
   {:else}
     {#each localSiteFields as field}
@@ -522,15 +513,7 @@
         </div>
       {/if}
     {:else}
-      <p class="empty-description">
-        {#if $userRole === 'developer'}
-          You'll need to create and integrate a field before you can edit
-          content from here
-        {:else}
-          The site developer will need to create and integrate a field before
-          you can edit content from here
-        {/if}
-      </p>
+      <NoFieldMessage />
     {/each}
   {/if}
 </main>
@@ -543,18 +526,6 @@
     color: var(--color-gray-2);
     background: var(--primo-color-black);
     overflow: scroll;
-
-    .empty-description {
-      color: var(--color-gray-4);
-      font-size: var(--font-size-2);
-      text-align: center;
-      height: 100%;
-      display: flex;
-      align-items: flex-start;
-      padding: 6rem;
-      justify-content: center;
-      margin-top: 12px;
-    }
 
     select {
       background-image: url("data:image/svg+xml;utf8,<svg fill='white' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>");


### PR DESCRIPTION
Let me know if you think this little cleanup is useful. I noticed this text was used in multiple places and thought it could be nice to make a component for it, let me know if you prefer I rename the component, move it elsewhere, or just feel free to close if you don't think this is useful.

Tests:
1. Make sure the text "You'll need to create and integrate a field before you can edit content from here" shows up as normal in the component editor, page field editor, and site field editor (when you're using the `developer` role)
2. Make sure the text "The site developer will need to create and integrate a field before you can edit content from here" shows in those places if you're logged in with a different role