### PR TITLE
changing class names to prevent clashes

### DIFF
--- a/src/lib/editor/field-types/Link.svelte
+++ b/src/lib/editor/field-types/Link.svelte
@@ -54,7 +54,7 @@
   }
 </script>
 
-<div class="link">
+<div class="primo-link">
   <span>{field.label}</span>
   <div class="inputs">
     <TextInput
@@ -109,7 +109,7 @@
 <slot />
 
 <style lang="postcss">
-  .link {
+  .primo-link {
     display: flex;
     flex-direction: column;
 

--- a/src/lib/editor/views/editor/ToolbarButton.svelte
+++ b/src/lib/editor/views/editor/ToolbarButton.svelte
@@ -71,7 +71,7 @@
 </button>
 
 <style lang="postcss">
-  .button {
+  .primo-button {
     font-size: 0.85rem;
     user-select: none;
     border-radius: 0;
@@ -95,14 +95,14 @@
     }
   }
 
-  .button.primo {
+  .primo-button.primo {
     padding: 7px 14px;
     color: var(--primo-color-white);
     border: 1.5px solid var(--primo-color-brand);
     border-radius: 0.25rem;
   }
 
-  .button {
+  .primo-button {
     height: 100%;
     color: var(--primo-color-white);
     font-weight: 400;
@@ -149,7 +149,7 @@
     }
   }
 
-  .button[disabled] {
+  .primo-button[disabled] {
     opacity: 0.1;
     cursor: default;
     transition: var(--transition-colors);

--- a/src/lib/editor/views/editor/ToolbarButton.svelte
+++ b/src/lib/editor/views/editor/ToolbarButton.svelte
@@ -27,7 +27,7 @@
 <button
   {id}
   aria-label={title}
-  class="button"
+  class="primo-button"
   class:primo={type === 'primo'}
   class:active
   class:has-subbuttons={buttons}


### PR DESCRIPTION
Theme classes were clashing with primo's UI classes because they had the same class names. I changed the classes in primo that were being overwritten by the themes ("button" & "link"). 