### PR TITLE
🚨  Fixed warning about unused CSS Selector

### DIFF
--- a/src/lib/ui/PrimaryButton.svelte
+++ b/src/lib/ui/PrimaryButton.svelte
@@ -82,7 +82,8 @@
       background: var(--primo-color-brand);
       color: var(--primo-color-black);
     }
-
+  }
+  button {
     &[type='submit'] {
       width: 100%;
     }


### PR DESCRIPTION
Primary button had nested css rules that applied both to button and label. Since <label> can't take those attributes I've splitted the style to only target button for those rules.