### PR TITLE
fix: Load favicon.png instead of favicon.ico

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,16 +2,17 @@
 <html lang="en">
 
 <head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	%sveltekit.head%
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/png" sizes="50x50" href="/favicon.png">
+  %sveltekit.head%
 </head>
 
 <body>
-	%sveltekit.body%
+  %sveltekit.body%
 
-	<link rel="preconnect" href="https://fonts.bunny.net">
-	<link href="https://fonts.bunny.net/css?family=inter:300,400,500,600,700,800" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.bunny.net">
+  <link href="https://fonts.bunny.net/css?family=inter:300,400,500,600,700,800" rel="stylesheet" />
 </body>
 
 </html>


### PR DESCRIPTION
A minor fix, but the `favicon` is currently not displayed, as it is incorrectly autoloaded (`favicon.ico` instead of `favicon.png`).