### PR TITLE
Fix :5173 dev server, onboarding docs, and unassigned first-site redirect

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -74,7 +74,7 @@ primo/
 4. **Access the application**
    - Main app: `http://localhost:8090` — the Go/PocketBase server serves the built app **and** the `/api/primo/*` backend together. **Use this URL.**
    - PocketBase Admin: `http://localhost:8090/_`
-   - Vite frontend (`http://localhost:5173`) — frontend-only with hot reload, but it does **not** serve the backend and has no proxy to it. Opening it directly leaves the editor stuck on the loader (every `/api/primo/*` request 404s, which surfaces as a `JSON.parse: unexpected character` error in the console). Iterate on frontend code here if you like, but load the app itself from `:8090`.
+   - Vite frontend (`http://localhost:5173`) — frontend dev server with hot reload. It proxies `/api`, `/_`, and the dev websocket to the Go server on `:8090`, so the editor works here too. Prefer `:8090` when in doubt — it serves the built app and PocketBase Admin directly.
 
 ### Available Scripts
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -43,6 +43,7 @@ primo/
 ### Prerequisites
 
 - [devenv](https://devenv.sh/) or [Dev Container](https://containers.dev/supporting) compatible development environment (eg. Visual Studio Code)
+- **git** must be installed and the project must be a valid git clone. On entering the devenv shell, devenv activates its `git-hooks` integration and will fail if git is missing or `.git` is in a bad state — a common snag on WSL2 when the repo lives on the Windows filesystem. Clone inside the Linux filesystem (e.g. `~/`, not `/mnt/c/…`) to avoid it.
 
 ### Getting Started
 
@@ -71,9 +72,9 @@ primo/
    This starts both the SvelteKit dev server and PocketBase backend.
 
 4. **Access the application**
-   - Main app: `http://localhost:5173`
+   - Main app: `http://localhost:8090` — the Go/PocketBase server serves the built app **and** the `/api/primo/*` backend together. **Use this URL.**
    - PocketBase Admin: `http://localhost:8090/_`
-   - Built app: `http://localhost:8090`
+   - Vite frontend (`http://localhost:5173`) — frontend-only with hot reload, but it does **not** serve the backend and has no proxy to it. Opening it directly leaves the editor stuck on the loader (every `/api/primo/*` request 404s, which surfaces as a `JSON.parse: unexpected character` error in the console). Iterate on frontend code here if you like, but load the app itself from `:8090`.
 
 ### Available Scripts
 

--- a/app.config.js
+++ b/app.config.js
@@ -7,7 +7,17 @@ export default defineConfig({
 		exclude: ['@rollup/browser']
 	},
 	server: {
-		host: true
+		host: true,
+		// The Vite dev server (:5173) only serves the frontend. The backend
+		// (/api/primo/*, PocketBase REST at /api/*, files, admin at /_, and the
+		// dev-reload websocket) is served by the Go server on :8090. Without
+		// this proxy every /api call 404s and the editor hangs on the loader.
+		proxy: {
+			'/api': { target: 'http://localhost:8090', changeOrigin: true, ws: true },
+			'/apis': { target: 'http://localhost:8090', changeOrigin: true },
+			'/_': { target: 'http://localhost:8090', changeOrigin: true },
+			'/__primo_dev_ws__': { target: 'http://localhost:8090', changeOrigin: true, ws: true }
+		}
 	},
 	build: {
 		rollupOptions: {

--- a/src/routes/site/+layout.svelte
+++ b/src/routes/site/+layout.svelte
@@ -8,7 +8,7 @@
 	import { page } from '$app/state'
 	import { Sites } from '$lib/pocketbase/collections'
 	import CreateSite from '$lib/components/CreateSite.svelte'
-	import { is_host_assigned } from '$lib/site_host'
+	import { is_host_assigned, site_editor_url } from '$lib/site_host'
 	import { current_user, set_current_user } from '$lib/pocketbase/user'
 	import { Loader } from 'lucide-svelte'
 
@@ -43,8 +43,12 @@
 						.catch(() => null)
 
 					if (!host_match && first_site.host) {
-						// Redirect to first site
-						window.location.href = `http://${first_site.host}/admin/site`
+						// Redirect to the first site's editor. Assigned sites live at
+						// their own vhost (//host/admin/site); unassigned sites
+						// (host === id) have no reachable vhost and must open by id at
+						// /admin/sites/{id} — otherwise the id gets used as a hostname
+						// and DNS fails. site_editor_url handles both cases.
+						window.location.href = site_editor_url(first_site)
 						return
 					}
 				} else {


### PR DESCRIPTION
Two follow-ups to the unassigned-host-sites feature (#1213) that landed locally after that PR merged and never made it onto \`main\`.

## Changes
- **Open unassigned first-site by id, not as a vhost** (\`src/routes/site/+layout.svelte\`) — the localhost "redirect to first site" path used \`first_site.host\` as a hostname unconditionally. For an unassigned site (\`host === id\`) that turns the id into a domain → \`DNS_PROBE_FINISHED_NXDOMAIN\`, so the operator can never reach their first site's editor. Now routes through \`site_editor_url\`, which sends unassigned sites to \`/admin/sites/{id}\`.
- **Make :5173 dev server usable + fix onboarding docs** (\`app.config.js\`, \`DEVELOPERS.md\`) — point developers at \`:8090\` (Go/PocketBase serves the built app *and* \`/api/primo/*\` together) as the URL to actually use; explain that \`:5173\` is frontend-only and 404s all backend calls. Adds a WSL2/git note to prerequisites.

## Why a fresh branch
These were committed on \`feature/unassigned-host-sites\` *after* it merged via #1213, so they were stranded off \`main\` and out of the dev deploy path. Cherry-picked cleanly onto \`origin/main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local development routing for backend APIs, administration, files, and development connections.
  * Improved site navigation to support both assigned hostnames and sites accessed by ID.

* **Documentation**
  * Clarified development prerequisites, including Git, valid clone requirements, and WSL2 filesystem guidance.
  * Updated local access instructions, including port 8090 as the preferred application URL, PocketBase Admin access, and port 5173 for the proxied frontend and editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->