### PR TITLE
Enable login rate limiting

### DIFF
--- a/migrations/1787000000_enable_rate_limits.go
+++ b/migrations/1787000000_enable_rate_limits.go
@@ -1,0 +1,40 @@
+package migrations
+
+import (
+	"os"
+
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+// Enable PocketBase's built-in IP rate limiter so the login endpoint has a
+// brute-force floor — Railway puts no WAF in front of us, so nothing else
+// throttles repeated auth-with-password attempts. PocketBase's default rules
+// already cover login (the *:auth rule is 2 req/3s), so we only flip the
+// Enabled toggle and leave Rules untouched.
+//
+// This is a dedicated migration (its own filename = its own identity) rather
+// than folding the change into 1757326540_settings.go: that migration reuses
+// the identity "1754640604_settings.js", which every existing install —
+// including prod and already-provisioned customers — recorded ~11 months ago,
+// so PocketBase would skip it and they'd never get rate limiting. A new
+// identity runs exactly once on fresh AND existing installs.
+//
+// Both states are assigned explicitly so the value tracks the env: set
+// PRIMO_RATE_LIMIT=off to disable (for self-hosters behind their own
+// proxy/WAF), and toggling it back on a later boot is a no-op here since the
+// migration only runs once — the admin UI remains the live control after that.
+func init() {
+	m.Register(
+		func(app core.App) error {
+			settings := app.Settings()
+			settings.RateLimits.Enabled = os.Getenv("PRIMO_RATE_LIMIT") != "off"
+			return app.Save(settings)
+		},
+		func(app core.App) error {
+			settings := app.Settings()
+			settings.RateLimits.Enabled = false
+			return app.Save(settings)
+		},
+	)
+}


### PR DESCRIPTION
## Why

`auth-with-password` (the login endpoint) had no brute-force protection. Railway puts no WAF in front of the instance, so nothing throttled repeated login attempts at any layer.

## What

Enable PocketBase's built-in IP rate limiter. Its default rules already cover login — the `*:auth` rule is 2 requests / 3s per IP — so we flip `RateLimits.Enabled` on and keep the default rules.

`PRIMO_RATE_LIMIT=off` opts out, for self-hosters running behind their own proxy/WAF.

**Delivered as a dedicated migration** (`1787000000_enable_rate_limits.go`), not a tweak to `1757326540_settings.go`. That existing migration reuses the identity `1754640604_settings.js`, which every existing install (prod + provisioned customers) recorded ~11 months ago — PocketBase skips already-applied identities, so folding the change in there would enable rate limiting on *fresh installs only*, missing exactly the running instances that need it. A new migration identity runs once on fresh **and** existing installs. The up func assigns `Enabled` explicitly from the env (true/false), and a down func flips it back off.

## Verified

Booted a fresh DB from a built binary and hammered the login endpoint:
- default: first 2 attempts return `400` (bad creds), then `429 Too Many Requests` — matches `*:auth` = 2 req/3s
- `go build ./...` + `go vet ./migrations/` pass

## Note

Binary change — ships on the next Railway redeploy / VERSION bump, not a CLI publish.

## Out of scope

OAuth/SSO, account lockout, HSTS. The `*:auth` rule covers the brute-force case; revisit only if we outgrow it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled built-in IP rate limiting by default to help protect the service from excessive requests.
  * Added an environment setting to disable rate limiting when needed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->