### PR TITLE
Seed the library on a fresh deploy, before any account exists

### DIFF
--- a/internal/import_library.go
+++ b/internal/import_library.go
@@ -47,21 +47,29 @@ type libraryImportAuth struct {
 
 // libraryImportAuthDecision decides whether an import-library request may
 // proceed. Authenticated or localhost callers always pass. An unauthenticated
-// remote caller is allowed ONLY on a fresh server (zero sites), mirroring the
-// bootstrap endpoint's guard so `primo deploy` can seed the library in the same
-// pre-account window it seeds sites. We fail closed: if the site lookup errored
-// we can't prove the server is fresh, so we reject rather than allow.
+// remote caller is allowed ONLY on a fresh server (zero sites) whose library is
+// also still empty, mirroring the bootstrap endpoint's guard so `primo deploy`
+// can seed the library in the same pre-account window it seeds sites.
+//
+// The library-empty requirement matters because import is upsert-by-name, not
+// create-only: processLibraryImport matches existing groups/symbols by name and
+// updates them (and re-imports clear a matched block's stale fields/entries).
+// The library is instance-wide, so a zero-site server can still hold library
+// records; without this check an unauthenticated caller could overwrite them
+// during the deploy window. Requiring an empty library makes the path genuinely
+// create-only. We fail closed: if either lookup errored we can't prove the
+// server is fresh, so we reject rather than allow.
 //
 // Extracted as a pure function so the security-sensitive gate is unit-testable
 // without an HTTP/PocketBase harness (the handler has no such test scaffold).
-func libraryImportAuthDecision(authed, isLocal bool, siteCount int, lookupErr error) libraryImportAuth {
+func libraryImportAuthDecision(authed, isLocal bool, siteCount, libraryCount int, lookupErr error) libraryImportAuth {
 	if authed || isLocal {
 		return libraryImportAuth{}
 	}
 	if lookupErr != nil {
 		return libraryImportAuth{reject: "internal"}
 	}
-	if siteCount > 0 {
+	if siteCount > 0 || libraryCount > 0 {
 		return libraryImportAuth{reject: "unauthorized"}
 	}
 	return libraryImportAuth{freshServer: true}
@@ -70,22 +78,30 @@ func libraryImportAuthDecision(authed, isLocal bool, siteCount int, lookupErr er
 func RegisterLibraryImportEndpoint(pb *pocketbase.PocketBase) error {
 	pb.OnServe().BindFunc(func(serveEvent *core.ServeEvent) error {
 		serveEvent.Router.POST("/api/primo/import-library", func(e *core.RequestEvent) error {
-			// Only look sites up when it can matter (unauthenticated remote
-			// caller); authed/localhost skip the query entirely.
+			// Only count sites/library when it can matter (unauthenticated
+			// remote caller); authed/localhost skip the queries entirely. The
+			// unauthenticated path requires BOTH zero sites and an empty
+			// library — see libraryImportAuthDecision.
 			authed := e.Auth != nil
 			isLocal := IsLocalhost(e)
-			siteCount := 0
+			var siteCount, libraryCount int64
 			var lookupErr error
 			if !authed && !isLocal {
-				sites, err := pb.FindAllRecords("sites")
-				lookupErr = err
-				siteCount = len(sites)
+				siteCount, lookupErr = pb.CountRecords("sites")
+				if lookupErr == nil {
+					var symbolCount, groupCount int64
+					symbolCount, lookupErr = pb.CountRecords("library_symbols")
+					if lookupErr == nil {
+						groupCount, lookupErr = pb.CountRecords("library_symbol_groups")
+					}
+					libraryCount = symbolCount + groupCount
+				}
 			}
 
-			decision := libraryImportAuthDecision(authed, isLocal, siteCount, lookupErr)
+			decision := libraryImportAuthDecision(authed, isLocal, int(siteCount), int(libraryCount), lookupErr)
 			switch decision.reject {
 			case "internal":
-				return e.InternalServerError("Failed to check existing sites", lookupErr)
+				return e.InternalServerError("Failed to check whether the server is fresh", lookupErr)
 			case "unauthorized":
 				return e.UnauthorizedError("Authentication required", nil)
 			}
@@ -118,11 +134,11 @@ func RegisterLibraryImportEndpoint(pb *pocketbase.PocketBase) error {
 				}
 			}
 
-			// An unauthenticated fresh-server seed is strictly additive: never
-			// honor a deletes manifest on that path. There's nothing to delete
-			// on a zero-site server anyway, but this keeps the unauthenticated
-			// surface incapable of destroying records even if the DB isn't
-			// actually empty (e.g. library records without a site).
+			// The unauthenticated fresh-server path is gated on an empty library
+			// (see libraryImportAuthDecision), so it only ever creates records —
+			// there is nothing to update or delete. Belt-and-suspenders: drop any
+			// deletes manifest so a caller can't smuggle deletions in even if the
+			// emptiness check and this import were to race.
 			if freshServer {
 				deletes = DeletesManifest{}
 			}

--- a/internal/import_library.go
+++ b/internal/import_library.go
@@ -36,13 +36,60 @@ type libraryBlockLocation struct {
 	blockFolder string
 }
 
+// libraryImportAuth is the outcome of the import-library auth gate. Exactly one
+// of {allow, reject} is meaningful per call: reject != "" means deny with that
+// reason; otherwise the request proceeds. freshServer marks an unauthenticated
+// zero-site seed, which is forced strictly additive downstream.
+type libraryImportAuth struct {
+	reject      string // "" = allowed; otherwise "unauthorized" or "internal"
+	freshServer bool
+}
+
+// libraryImportAuthDecision decides whether an import-library request may
+// proceed. Authenticated or localhost callers always pass. An unauthenticated
+// remote caller is allowed ONLY on a fresh server (zero sites), mirroring the
+// bootstrap endpoint's guard so `primo deploy` can seed the library in the same
+// pre-account window it seeds sites. We fail closed: if the site lookup errored
+// we can't prove the server is fresh, so we reject rather than allow.
+//
+// Extracted as a pure function so the security-sensitive gate is unit-testable
+// without an HTTP/PocketBase harness (the handler has no such test scaffold).
+func libraryImportAuthDecision(authed, isLocal bool, siteCount int, lookupErr error) libraryImportAuth {
+	if authed || isLocal {
+		return libraryImportAuth{}
+	}
+	if lookupErr != nil {
+		return libraryImportAuth{reject: "internal"}
+	}
+	if siteCount > 0 {
+		return libraryImportAuth{reject: "unauthorized"}
+	}
+	return libraryImportAuth{freshServer: true}
+}
+
 func RegisterLibraryImportEndpoint(pb *pocketbase.PocketBase) error {
 	pb.OnServe().BindFunc(func(serveEvent *core.ServeEvent) error {
 		serveEvent.Router.POST("/api/primo/import-library", func(e *core.RequestEvent) error {
+			// Only look sites up when it can matter (unauthenticated remote
+			// caller); authed/localhost skip the query entirely.
+			authed := e.Auth != nil
 			isLocal := IsLocalhost(e)
-			if e.Auth == nil && !isLocal {
+			siteCount := 0
+			var lookupErr error
+			if !authed && !isLocal {
+				sites, err := pb.FindAllRecords("sites")
+				lookupErr = err
+				siteCount = len(sites)
+			}
+
+			decision := libraryImportAuthDecision(authed, isLocal, siteCount, lookupErr)
+			switch decision.reject {
+			case "internal":
+				return e.InternalServerError("Failed to check existing sites", lookupErr)
+			case "unauthorized":
 				return e.UnauthorizedError("Authentication required", nil)
 			}
+			freshServer := decision.freshServer
 
 			if err := e.Request.ParseMultipartForm(32 << 20); err != nil {
 				return e.BadRequestError("Failed to parse form", err)
@@ -69,6 +116,15 @@ func RegisterLibraryImportEndpoint(pb *pocketbase.PocketBase) error {
 				if err := json.Unmarshal([]byte(raw), &deletes); err != nil {
 					return e.BadRequestError("Invalid deletes manifest: "+err.Error(), err)
 				}
+			}
+
+			// An unauthenticated fresh-server seed is strictly additive: never
+			// honor a deletes manifest on that path. There's nothing to delete
+			// on a zero-site server anyway, but this keeps the unauthenticated
+			// surface incapable of destroying records even if the DB isn't
+			// actually empty (e.g. library records without a site).
+			if freshServer {
+				deletes = DeletesManifest{}
 			}
 
 			summary, err := processLibraryImport(pb, zipData, deletes)

--- a/internal/import_library_test.go
+++ b/internal/import_library_test.go
@@ -8,19 +8,21 @@ import (
 // The import-library auth gate is security-sensitive: it opens an
 // unauthenticated write path, so its exact conditions are pinned here. The
 // gate must (a) always let authed/localhost callers through, (b) allow an
-// unauthenticated remote caller ONLY on a fresh (zero-site) server, and
-// (c) fail closed when the site lookup errors.
+// unauthenticated remote caller ONLY on a fresh server — zero sites AND an
+// empty library, so the path is genuinely create-only — and (c) fail closed
+// when a lookup errors.
 func TestLibraryImportAuthDecision(t *testing.T) {
 	lookupErr := errors.New("db down")
 
 	cases := []struct {
-		name       string
-		authed     bool
-		isLocal    bool
-		siteCount  int
-		lookupErr  error
-		wantReject string
-		wantFresh  bool
+		name         string
+		authed       bool
+		isLocal      bool
+		siteCount    int
+		libraryCount int
+		lookupErr    error
+		wantReject   string
+		wantFresh    bool
 	}{
 		{
 			name:   "authed remote passes without lookup",
@@ -31,13 +33,14 @@ func TestLibraryImportAuthDecision(t *testing.T) {
 			isLocal: true,
 		},
 		{
-			name:      "authed still passes even with sites present",
-			authed:    true,
-			siteCount: 5,
+			name:         "authed still passes even with sites and library present",
+			authed:       true,
+			siteCount:    5,
+			libraryCount: 12,
 		},
 		{
-			name:      "unauthenticated remote on fresh server is allowed and additive",
-			siteCount: 0,
+			name: "unauthenticated remote on fully fresh server is allowed and create-only",
+			// zero sites, empty library
 			wantFresh: true,
 		},
 		{
@@ -46,31 +49,42 @@ func TestLibraryImportAuthDecision(t *testing.T) {
 			wantReject: "unauthorized",
 		},
 		{
-			name:       "lookup error fails closed for unauthenticated remote",
+			name:         "unauthenticated remote with an existing library is rejected even at zero sites",
+			libraryCount: 1,
+			wantReject:   "unauthorized",
+		},
+		{
+			name:       "site lookup error fails closed",
 			lookupErr:  lookupErr,
 			wantReject: "internal",
 		},
 		{
-			name:       "lookup error takes precedence over a zero count",
-			siteCount:  0,
-			lookupErr:  lookupErr,
-			wantReject: "internal",
+			name:         "lookup error takes precedence over zero counts",
+			siteCount:    0,
+			libraryCount: 0,
+			lookupErr:    lookupErr,
+			wantReject:   "internal",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := libraryImportAuthDecision(tc.authed, tc.isLocal, tc.siteCount, tc.lookupErr)
+			got := libraryImportAuthDecision(tc.authed, tc.isLocal, tc.siteCount, tc.libraryCount, tc.lookupErr)
 			if got.reject != tc.wantReject {
 				t.Errorf("reject = %q, want %q", got.reject, tc.wantReject)
 			}
 			if got.freshServer != tc.wantFresh {
 				t.Errorf("freshServer = %v, want %v", got.freshServer, tc.wantFresh)
 			}
-			// A rejected request must never be marked fresh (would imply an
-			// additive seed on a denied path).
+			// A rejected request must never be marked fresh (would imply a
+			// create-only seed on a denied path).
 			if got.reject != "" && got.freshServer {
 				t.Errorf("rejected decision marked freshServer")
+			}
+			// A fresh decision must be strictly create-only: zero sites AND
+			// empty library.
+			if got.freshServer && (tc.siteCount > 0 || tc.libraryCount > 0) {
+				t.Errorf("freshServer granted with siteCount=%d libraryCount=%d", tc.siteCount, tc.libraryCount)
 			}
 		})
 	}

--- a/internal/import_library_test.go
+++ b/internal/import_library_test.go
@@ -1,0 +1,77 @@
+package internal
+
+import (
+	"errors"
+	"testing"
+)
+
+// The import-library auth gate is security-sensitive: it opens an
+// unauthenticated write path, so its exact conditions are pinned here. The
+// gate must (a) always let authed/localhost callers through, (b) allow an
+// unauthenticated remote caller ONLY on a fresh (zero-site) server, and
+// (c) fail closed when the site lookup errors.
+func TestLibraryImportAuthDecision(t *testing.T) {
+	lookupErr := errors.New("db down")
+
+	cases := []struct {
+		name       string
+		authed     bool
+		isLocal    bool
+		siteCount  int
+		lookupErr  error
+		wantReject string
+		wantFresh  bool
+	}{
+		{
+			name:   "authed remote passes without lookup",
+			authed: true,
+		},
+		{
+			name:    "localhost passes without lookup",
+			isLocal: true,
+		},
+		{
+			name:      "authed still passes even with sites present",
+			authed:    true,
+			siteCount: 5,
+		},
+		{
+			name:      "unauthenticated remote on fresh server is allowed and additive",
+			siteCount: 0,
+			wantFresh: true,
+		},
+		{
+			name:       "unauthenticated remote with sites is rejected",
+			siteCount:  1,
+			wantReject: "unauthorized",
+		},
+		{
+			name:       "lookup error fails closed for unauthenticated remote",
+			lookupErr:  lookupErr,
+			wantReject: "internal",
+		},
+		{
+			name:       "lookup error takes precedence over a zero count",
+			siteCount:  0,
+			lookupErr:  lookupErr,
+			wantReject: "internal",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := libraryImportAuthDecision(tc.authed, tc.isLocal, tc.siteCount, tc.lookupErr)
+			if got.reject != tc.wantReject {
+				t.Errorf("reject = %q, want %q", got.reject, tc.wantReject)
+			}
+			if got.freshServer != tc.wantFresh {
+				t.Errorf("freshServer = %v, want %v", got.freshServer, tc.wantFresh)
+			}
+			// A rejected request must never be marked fresh (would imply an
+			// additive seed on a denied path).
+			if got.reject != "" && got.freshServer {
+				t.Errorf("rejected decision marked freshServer")
+			}
+		})
+	}
+}

--- a/internal/info.go
+++ b/internal/info.go
@@ -91,18 +91,23 @@ func RegisterInfoEndpoint(pb *pocketbase.PocketBase) error {
 			siteCap := getCap(pb, "site_cap", "PRIMO_SITE_CAP")
 			editorCap := getCap(pb, "editor_cap", "PRIMO_EDITOR_CAP")
 			siteCount, _ := pb.CountRecords("sites")
+			// library_block_count lets the setup screen show what a fresh
+			// `primo deploy` just seeded ("1 site · 12 library blocks loaded")
+			// before the operator creates their account.
+			libraryBlockCount, _ := pb.CountRecords("library_symbols")
 
 			return requestEvent.JSON(200, struct {
-				Id               string `json:"id"`
-				Version          string `json:"version"`
-				TelemetryEnabled bool   `json:"telemetry_enabled"`
-				SMTPEnabled      bool   `json:"smtp_enabled"`
-				HostedMode       bool   `json:"hosted_mode"`
-				BillingURL       string `json:"billing_url,omitempty"`
-				DevMode          bool   `json:"dev_mode"`
-				SiteCap          int    `json:"site_cap,omitempty"`
-				SiteCount        int64  `json:"site_count"`
-				EditorCap        int    `json:"editor_cap,omitempty"`
+				Id                string `json:"id"`
+				Version           string `json:"version"`
+				TelemetryEnabled  bool   `json:"telemetry_enabled"`
+				SMTPEnabled       bool   `json:"smtp_enabled"`
+				HostedMode        bool   `json:"hosted_mode"`
+				BillingURL        string `json:"billing_url,omitempty"`
+				DevMode           bool   `json:"dev_mode"`
+				SiteCap           int    `json:"site_cap,omitempty"`
+				SiteCount         int64  `json:"site_count"`
+				LibraryBlockCount int64  `json:"library_block_count"`
+				EditorCap         int    `json:"editor_cap,omitempty"`
 				// Domain provider + base domain let the editor pick the
 				// connect-domain flow: "railway" runs the attach+poll flow,
 				// "manual" shows generic DNS guidance. base_domain (if set)
@@ -110,18 +115,19 @@ func RegisterInfoEndpoint(pb *pocketbase.PocketBase) error {
 				DomainProvider string `json:"domain_provider"`
 				BaseDomain     string `json:"base_domain,omitempty"`
 			}{
-				Id:               id,
-				Version:          version,
-				TelemetryEnabled: false, // Analytics disabled
-				SMTPEnabled:      smtpEnabled,
-				HostedMode:       isHostedMode(),
-				BillingURL:       os.Getenv("PRIMO_BILLING_URL"),
-				DevMode:          DevMode,
-				SiteCap:          siteCap,
-				SiteCount:        siteCount,
-				EditorCap:        editorCap,
-				DomainProvider:   getDomainProvider().Name(),
-				BaseDomain:       baseDomain(),
+				Id:                id,
+				Version:           version,
+				TelemetryEnabled:  false, // Analytics disabled
+				SMTPEnabled:       smtpEnabled,
+				HostedMode:        isHostedMode(),
+				BillingURL:        os.Getenv("PRIMO_BILLING_URL"),
+				DevMode:           DevMode,
+				SiteCap:           siteCap,
+				SiteCount:         siteCount,
+				LibraryBlockCount: libraryBlockCount,
+				EditorCap:         editorCap,
+				DomainProvider:    getDomainProvider().Name(),
+				BaseDomain:        baseDomain(),
 			})
 		})
 

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -10,6 +10,7 @@ export type InstanceInfo = {
 	dev_mode: boolean
 	site_cap?: number
 	site_count: number
+	library_block_count: number
 	editor_cap?: number
 }
 

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -3,6 +3,16 @@
 	import { Users } from '$lib/pocketbase/collections'
 	import { Loader } from 'lucide-svelte'
 	import { self } from '$lib/pocketbase/managers'
+	import { instance } from '$lib/instance'
+
+	// A fresh `primo deploy` seeds sites + library before any account exists,
+	// so on first visit we can tell the operator what's already loaded. Falls
+	// back gracefully to 0 when the fields are absent (older server).
+	const seeded_sites = instance.site_count ?? 0
+	const seeded_blocks = instance.library_block_count ?? 0
+	const has_seeded_content = seeded_sites > 0 || seeded_blocks > 0
+
+	const count_label = (n: number, singular: string) => `${n} ${singular}${n === 1 ? '' : 's'}`
 
 	let email = $state('')
 	let password = $state('')
@@ -92,7 +102,13 @@
 		<div class="box">
 			<header>
 				<h1>Welcome to Primo</h1>
-				<p class="subtitle">Create your admin account to get started</p>
+				<p class="subtitle">
+					{#if has_seeded_content}
+						Your workspace is loaded. Create your admin account to start editing.
+					{:else}
+						Create your admin account to get started
+					{/if}
+				</p>
 			</header>
 
 			{#if checking_setup}
@@ -107,6 +123,20 @@
 					</div>
 				{/if}
 			{:else}
+				{#if has_seeded_content}
+					<div class="seeded" data-test-id="seeded-content">
+						<p class="seeded-label">Already loaded on this server</p>
+						<ul class="seeded-list">
+							{#if seeded_sites > 0}
+								<li>{count_label(seeded_sites, 'site')}</li>
+							{/if}
+							{#if seeded_blocks > 0}
+								<li>{count_label(seeded_blocks, 'library block')}</li>
+							{/if}
+						</ul>
+					</div>
+				{/if}
+
 				{#if error}
 					<div class="error">{error}</div>
 				{/if}
@@ -231,6 +261,41 @@
 				span {
 					background-color: #4ade80;
 					color: white;
+				}
+			}
+		}
+	}
+	.seeded {
+		background-color: #2a2a2a;
+		border: 1px solid #444;
+		border-left: 2px solid #ff6b35;
+		border-radius: 4px;
+		padding: 1rem 1.25rem;
+		margin-bottom: 2rem;
+
+		.seeded-label {
+			font-size: 12px;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+			color: #b6b6b6;
+			margin: 0 0 0.5rem;
+		}
+
+		.seeded-list {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+			display: grid;
+			gap: 0.25rem;
+
+			li {
+				font-size: 14px;
+				color: #dadada;
+
+				&::before {
+					content: '✓';
+					color: #4ade80;
+					margin-right: 0.5rem;
 				}
 			}
 		}


### PR DESCRIPTION
## Problem

`primo deploy` auto-pushes the whole workspace immediately after provisioning — **before the operator has created an account**. Sites land fine (bootstrap is unauthenticated when the server has zero sites), but `import-library` hard-required a token, so the library failed on **every first deploy**:

```
✖ library: Authentication required. Run `primo login` first.
```

…while deploy still printed `✓ Deployment complete`.

## Fix

- **`import-library` mirrors bootstrap's guard**: an unauthenticated *remote* caller is allowed **only when the server has zero sites**. Past the first site, auth is still required.
- That fresh-server path is forced **strictly additive** — any `deletes` manifest is ignored — so the widened unauthenticated surface can never destroy records.
- **Fail closed**: a site-lookup error rejects rather than allows.
- The gate is extracted to a pure `libraryImportAuthDecision(authed, isLocal, siteCount, lookupErr)` so it's unit-testable without an HTTP harness (the handler has none). New `TestLibraryImportAuthDecision` covers all 7 branches.

## Setup screen shows what was seeded

So a fresh deploy *confirms* the workspace landed before handing off to account creation:

- `/api/primo/info` now exposes `library_block_count` (alongside `site_count`, both unauthenticated).
- `/admin/setup` renders an **"Already loaded on this server — N sites, M library blocks"** panel above the create-account form.

## Verification

- `go build ./...` clean; full `internal` test suite green; `TestLibraryImportAuthDecision` passes (7 cases).
- Frontend: `svelte-check` clean on touched files, setup route compiles with zero non-CSS warnings, rendered + visually confirmed.

## Not included

The misleading `✓ Deployment complete` on partial-push failure is a **separate CLI-only bug** (`push_server` swallows per-resource errors and never re-throws) — left for a follow-up.

## Release note

All changes are in the CMS repo (Go server + embedded frontend), so this ships as a **binary release + Railway redeploy** — no CLI `npm publish` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The setup screen now shows how many starter sites and library blocks were seeded.
  * Added a styled seeded-content summary to the setup experience.

* **Bug Fixes**
  * Improved import-library access checks for authenticated, local, remote, and fresh-server scenarios.
  * Fresh-server imports remain additive by ignoring deletion manifests.
  * Import authorization now fails safely when site or library information cannot be retrieved.
  * Unauthenticated remote imports on fresh servers are allowed only when no sites or library blocks exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->