### PR TITLE
Keep gating setup until an account actually exists

### DIFF
--- a/internal/admin.go
+++ b/internal/admin.go
@@ -57,9 +57,18 @@ func RegisterAdminApp(pb *pocketbase.PocketBase) error {
 					setupRequired := superuserCount == 0
 					isSetup := requestEvent.Request.URL.Path == "/admin/setup"
 					isFile := path.Ext(requestEvent.Request.URL.Path) != ""
-					if setupRequired && !isSetup && !isFile {
-						return requestEvent.Redirect(302, "/admin/setup")
+					if setupRequired {
+						// Setup isn't done yet — keep gating. Redirect every
+						// non-setup page (incl. /admin/auth) back to /admin/setup
+						// so an abandoned setup can't leave the instance stuck at
+						// the auth dead-end. Never latch setupCompleted here: a
+						// visit to /admin/setup itself must not count as "done".
+						if !isSetup && !isFile {
+							return requestEvent.Redirect(302, "/admin/setup")
+						}
 					} else {
+						// A real superuser exists — setup is genuinely complete.
+						// Latch so we stop counting superusers on every request.
 						setupCompleted = true
 					}
 				}


### PR DESCRIPTION
## Problem
On a fresh deploy (no account yet), the bare domain correctly went to the setup screen the first time. But a second visit landed on `/admin/auth` — a dead end, since the server was never set up and no account exists to sign in with.

## Cause
`RegisterAdminApp`'s `setupCompleted` flag was latched to `true` in the `else` branch that also fires when serving `/admin/setup` itself (`isSetup=true` makes the redirect condition false). So the very first request to the setup page marked setup "complete" before any superuser existed, and every later `/admin/*` request skipped the gate — letting the root page's redirect to `/admin/auth` stick.

## Fix
Only latch `setupCompleted` when a real superuser exists (`!setupRequired`). While setup is still required, redirect every non-setup, non-file `/admin/*` request back to `/admin/setup`, so an abandoned setup can't strand the instance at the auth dead-end.

## Verification
- `go build ./internal/` ✅
- Traced the request flow (fresh deploy → setup → revisit); no automated test — the gate lives in a router closure that needs a PocketBase test app to exercise. Will verify on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved administrative setup handling to ensure setup-required requests are redirected appropriately.
  * Prevented setup completion state from being recorded while setup is still required.
  * Preserved setup completion tracking once setup requirements are no longer active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->