### PR TITLE
Deploy on release publish, not tag push

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,9 +1,14 @@
 name: Build and push Docker image
 
+# Publishing a GitHub release IS the production deploy: this pushes the image
+# (including :latest, which Railway auto-redeploys on) only when a release is
+# published. A tag push alone now just builds binaries into a draft release
+# (release.yml) — review the draft, publish it, and that rolls prod. Before
+# 2026-09 this triggered on the tag push itself, which deployed to Railway the
+# moment a tag landed, making draft releases a decorative gate.
 on:
-  push:
-    tags:
-      - v3.*
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -11,6 +16,9 @@ env:
 
 jobs:
   build-image:
+    # Mirror the old `tags: v3.*` scoping — release events can't filter by tag
+    # pattern in `on:`, so guard here instead.
+    if: startsWith(github.event.release.tag_name, 'v3.')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem
`tag.yml` triggered on the tag push itself, pushing ghcr `:latest` immediately — and Railway auto-redeploys on `:latest` updates. So pushing a version tag deployed production before the draft release was ever reviewed (observed on v3.2.7: Railway sent "Service upgraded to latest" while the release was still a draft). Draft releases were a decorative gate.

## Change
Trigger on `release: types: [published]` instead. New flow:
1. Push a `v3.*` tag → `release.yml` (unchanged) builds binaries into a **draft** release
2. Review the draft, publish it
3. Publishing fires this workflow → image built + pushed (`:X.Y.Z`, `:X.Y`, `:X`, `:latest`) → Railway rolls

Release events can't pattern-filter tags in `on:`, so the old `v3.*` scoping moved to a job-level `if` on `github.event.release.tag_name`. `github.ref_name` and the checkout still resolve to the tag on release events, so `PRIMO_VERSION` stamping and semver image tags are unaffected.

## Notes
- v3.2.7 was published before this change landed, so publishing it did not double-build.
- Docs-adjacent memory: publishing a release is now the prod deploy trigger; a bare tag push deploys nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release automation to run when version 3 releases are published.
  - Container image building and publishing continue to operate as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->